### PR TITLE
fix: animation reset on modal changes

### DIFF
--- a/src/components/Models/AnimationModel/AnimationModel.component.tsx
+++ b/src/components/Models/AnimationModel/AnimationModel.component.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, FC } from 'react';
+import React, { useRef, FC, useMemo } from 'react';
 import { useFrame, useGraph } from '@react-three/fiber';
 import { AnimationMixer, Group } from 'three';
 import { Model } from 'src/components/Models/Model';
@@ -31,12 +31,18 @@ export const AnimationModel: FC<AnimationModelProps> = ({
   const { nodes } = useGraph(scene);
 
   const animationSource = useGltfLoader(animationSrc);
-  const mixer = new AnimationMixer(nodes.Armature);
-  mixer.clipAction(animationSource.animations[0]).play();
-  mixer.update(0);
+
+  const animationMixer = useMemo(() => {
+    const mixer = new AnimationMixer(nodes.Armature);
+
+    mixer.clipAction(animationSource.animations[0]).play();
+    mixer.update(0);
+
+    return mixer;
+  }, [animationSource.animations, nodes.Armature]);
 
   useFrame((state, delta) => {
-    mixer?.update(delta);
+    animationMixer?.update(delta);
 
     if (!idleRotation) {
       return;


### PR DESCRIPTION
This fixes the bug when the looping animation resets on modal changes.

Here is a video to demonstrate:

https://user-images.githubusercontent.com/33582626/213699947-70ae0d14-c179-4430-ab2d-893479d666b7.mov

And after the fix:

https://user-images.githubusercontent.com/33582626/213700214-7921ef14-c168-429e-b746-4cde994aa37f.mov


