### PR TITLE
fix: allow blob model for exhibit component

### DIFF
--- a/src/components/Exhibit/Exhibit.component.tsx
+++ b/src/components/Exhibit/Exhibit.component.tsx
@@ -12,7 +12,7 @@ export interface ExhibitProps extends CameraProps, EnvironmentProps {
   /**
    * Arbitrary binary data (base64 string | Blob) of a `.glb` file or path (URL) to a `.glb` resource.
    */
-  modelSrc: string;
+  modelSrc: string | Blob;
   /**
    * Size of the rendered GLB model.
    */

--- a/src/components/Models/FloatingModel/FloatingModel.component.tsx
+++ b/src/components/Models/FloatingModel/FloatingModel.component.tsx
@@ -6,7 +6,7 @@ import { useGltfLoader } from 'src/services';
 import { BaseModelProps } from 'src/types';
 
 export interface FloatingModelProps extends BaseModelProps {
-  modelSrc: string;
+  modelSrc: string | Blob;
   scale?: number;
 }
 


### PR DESCRIPTION
## Changes

- fixed modelSrc type for `Exhibit` component
- fixed modelSrc type for `FloatingModel` component