### PR TITLE
Act 283 visage memory leak when switching avatar sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,6 @@ Visage is available as an [npm package](https://www.npmjs.com/package/@readyplay
 npm install @readyplayerme/visage
 ```
 
-Make sure to install peer-dependencies if your project doesn't already include them:
-```sh
-npm install @react-three/drei@9.79.3 @react-three/fiber@8.13.5 @react-three/postprocessing@2.15.0 three@0.154.0 three-stdlib@2.23.13 suspend-react@0.1.3 postprocessing@6.32.2
-```
-
 # Documentation & examples
 
 You can find all **code examples** of the components and their **documentation** on [our GitHub page](https://readyplayerme.github.io/visage/).

--- a/src/services/Models.service.tsx
+++ b/src/services/Models.service.tsx
@@ -14,7 +14,7 @@ import {
 import { useFrame } from '@react-three/fiber';
 import type { ObjectMap, SkinnedMeshProps } from '@react-three/fiber';
 import { GLTF, GLTFLoader, DRACOLoader } from 'three-stdlib';
-import { suspend } from 'suspend-react';
+import { suspend, clear } from 'suspend-react';
 import { Emotion } from 'src/components/Avatar/Avatar.component';
 import { BloomConfiguration } from 'src/types';
 
@@ -212,6 +212,7 @@ loader.setDRACOLoader(dracoLoader);
 
 export const useGltfLoader = (source: Blob | string): GLTF =>
   suspend(async () => {
+    clear();
     if (source instanceof Blob) {
       const buffer = await source.arrayBuffer();
       return (await loader.parseAsync(buffer, '')) as unknown as GLTF;


### PR DESCRIPTION
**Fixed**
* Issue with suspended components keeping GLTFParser instances alive. The effect is amplified the more you switch model sources depending on the model size.


Simple test case can be run by switching the avatars in the showcase example and doing a memory snapshot.

**Without** **clearing** suspended objects. Baseline 60MB will grow to 97MB = 37MB increase
<img width="946" alt="Screenshot 2023-11-07 at 15 49 41" src="https://github.com/readyplayerme/visage/assets/14032500/acd26cd1-1c1d-4140-83a5-c70a8d66e62c">

In this case the snapshot also will show that GLTFParser is duplicated 6 times.
<img width="631" alt="Screenshot 2023-11-07 at 15 57 02" src="https://github.com/readyplayerme/visage/assets/14032500/178baa9b-2ba2-4928-acd3-9e7f13d7c10a">


**With clearing** suspended objects. Data will gro from 58MB to 71MB = 13MB increase
<img width="929" alt="Screenshot 2023-11-07 at 15 48 24" src="https://github.com/readyplayerme/visage/assets/14032500/ebc0479d-e442-44ee-b825-ea1e4e378f2c">
