### PR TITLE
fix(effects): render bloom effect by default

### DIFF
--- a/src/components/Avatar/Avatar.component.tsx
+++ b/src/components/Avatar/Avatar.component.tsx
@@ -272,7 +272,7 @@ const Avatar: FC<AvatarProps> = ({
       {background?.src && <Box {...background} />}
       {capture && <Capture {...capture} />}
       {background?.color && <BackgroundColor color={background.color} />}
-      {effects && (
+      {(effects?.ambientOcclusion || effects?.bloom) && (
         <EffectComposer autoClear multisampling={4}>
           <>
             {effects?.ambientOcclusion && (


### PR DESCRIPTION
The problem was that we were rendering the effect composer without any effects in some cases. This caused the avatars look like this:
![image](https://github.com/readyplayerme/visage/assets/33582626/ad3e483e-16b3-47b5-8fdf-de9f8f8c930a)