### PR TITLE
fix(deviceDetector): ACT-841 replace benchmark to s3, add timeout

### DIFF
--- a/src/hooks/useDeviceDetector/use-device-detector.hook.ts
+++ b/src/hooks/useDeviceDetector/use-device-detector.hook.ts
@@ -25,8 +25,8 @@ type NetworkTierResult = {
 
 // in mbps
 const networkTierGrades = {
-  1: 1,
-  2: 10,
+  1: 0.7,
+  2: 2,
   3: Infinity
 };
 
@@ -83,7 +83,7 @@ export function useDeviceDetector(options?: DeviceDetectorHookProps) {
           gpuTierResult.tier = 3;
         }
 
-        const downloadSpeed = await checkDownloadSpeed('https://api.readyplayer.me/v3/avatars/editor/benchmark');
+        const downloadSpeed = await checkDownloadSpeed('https://readyplayerme-avatars.s3.amazonaws.com/benchmark.glb');
 
         let tier = 3;
         if (downloadSpeed < networkTierGrades[1]) {

--- a/src/services/DownloadSpeed.service.ts
+++ b/src/services/DownloadSpeed.service.ts
@@ -1,17 +1,25 @@
 export async function checkDownloadSpeed(baseUrl: string): Promise<number> {
   const startTime = performance.now();
 
-  const response = await fetch(baseUrl);
+  try {
+    const response = await fetch(baseUrl, { signal: AbortSignal.timeout(4000) });
 
-  const data = await response.blob();
+    const data = await response.blob();
 
-  const endTime = performance.now();
+    const endTime = performance.now();
 
-  const duration = (endTime - startTime) / 1000; // convert to seconds
-  const sizeInBytes = data.size;
-  const sizeInMegabits = (sizeInBytes * 8) / (1024 * 1024); // convert to megabits
+    const duration = (endTime - startTime) / 1000; // convert to seconds
+    const sizeInBytes = data.size;
+    const sizeInMegabits = (sizeInBytes * 8) / (1024 * 1024); // convert to megabits
 
-  const speedMbps = sizeInMegabits / duration;
+    const speedMbps = sizeInMegabits / duration;
 
-  return speedMbps;
+    return speedMbps;
+  } catch (error) {
+    if (['TimeoutError', 'AbortError'].includes((error as Error).name)) {
+      return 0;
+    }
+
+    return 10;
+  }
 }


### PR DESCRIPTION
Use S3 file as a benchmark.
Handle timeouts.
Reconfigure network tiers.