### PR TITLE
fix: camera controls supports multiple visage instances

### DIFF
--- a/src/components/Scene/CameraControls.component.tsx
+++ b/src/components/Scene/CameraControls.component.tsx
@@ -75,6 +75,7 @@ export const CameraControls: FC<CameraControlsProps> = ({
 
     const controls = controlsRef.current;
     if (controls) {
+      controls.target.set(0, fallbackCameraTarget, 0);
       controls.update();
 
       // TODO: Look for a better distance initialiser, without progress value check it conflicts with cameraZoomTarget which also can update camera position.z
@@ -83,7 +84,7 @@ export const CameraControls: FC<CameraControlsProps> = ({
         controls.update();
       }
     }
-  }, [cameraInitialDistance, camera, gl.domElement, cameraZoomTarget]);
+  }, [cameraInitialDistance, camera, gl.domElement, cameraZoomTarget, fallbackCameraTarget]);
 
   useFrame((_, delta) => {
     if (updateCameraTargetOnZoom && controlsRef.current) {

--- a/src/components/Scene/CameraControls.component.tsx
+++ b/src/components/Scene/CameraControls.component.tsx
@@ -75,6 +75,8 @@ export const CameraControls: FC<CameraControlsProps> = ({
 
     const controls = controlsRef.current;
     if (controls) {
+      controls.update();
+
       // TODO: Look for a better distance initialiser, without progress value check it conflicts with cameraZoomTarget which also can update camera position.z
       if (cameraInitialDistance && progressRef.current === Number.POSITIVE_INFINITY) {
         camera.position.z = cameraInitialDistance;

--- a/src/components/Scene/CameraControls.component.tsx
+++ b/src/components/Scene/CameraControls.component.tsx
@@ -81,10 +81,6 @@ export const CameraControls: FC<CameraControlsProps> = ({
         controls.update();
       }
     }
-
-    return () => {
-      controls?.dispose();
-    };
   }, [cameraInitialDistance, camera, gl.domElement, cameraZoomTarget]);
 
   useFrame((_, delta) => {


### PR DESCRIPTION
- fixed camera controls issues to support multiple visage instances

#### Implementation
- `controls` and `progress` are used to be declared on the module level. It causes issues with camera positions if multiple visage instances are rendered on the screen at the same time.
- moved `controls` and `progress` from module level to React component level so multiple visage instances have their own camera controls instances.