### PR TITLE
Fix capture for updated threejs version

### DIFF
--- a/src/App/App.component.tsx
+++ b/src/App/App.component.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { AvatarDevelop } from './components/Develop';
 import { AvatarTest } from './components/Test';
 import { AvatarNova } from './components/Nova';
+import { AvatarCapture } from './components/Capture';
 
 import styles from './App.module.scss';
 
@@ -18,6 +19,10 @@ const router = createBrowserRouter([
   {
     path: '/nova',
     element: <AvatarNova />
+  },
+  {
+    path: '/capture-canvas',
+    element: <AvatarCapture />
   }
 ]);
 

--- a/src/App/components/Capture.tsx
+++ b/src/App/components/Capture.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { StatsGl } from '@react-three/drei';
+import { Vector3 } from 'three';
+
+import { Avatar } from 'src/components/Avatar';
+import { SettingsPanel } from './SettingsPanel';
+
+const modelUrl = 'https://avatars.readyplayer.dev/6735d9cb1f22bfcc50a037ec.glb';
+
+export const AvatarCapture: React.FC = () => {
+  const [isCapturing, setIsCapturing] = useState<boolean>(false);
+  const [base64, setBase64] = useState<string | undefined>();
+
+  const capture = async (image?: string) => {
+    setBase64(image);
+    setIsCapturing(false);
+  };
+
+  return (
+    <>
+      <SettingsPanel>
+        <button type="button" onClick={() => setIsCapturing(true)}>
+          CAPTURE
+        </button>
+      </SettingsPanel>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', height: '100%', placeItems: 'center' }}>
+        <Avatar
+          modelSrc={modelUrl}
+          cameraTarget={1.5}
+          halfBody={false}
+          emotion={{
+            mouthSmileLeft: 0.6,
+            mouthSmileRight: 0.6
+          }}
+          environment="https://readyplayerme-assets.s3.amazonaws.com/environment/soft.hdr"
+          cameraInitialDistance={2.5}
+          capture={{
+            trigger: isCapturing,
+            callBack: capture,
+            settings: {
+              quality: 0.9,
+
+              type: 'image/jpeg'
+            }
+          }}
+          background={{
+            src: 'https://upload.wikimedia.org/wikipedia/commons/d/d0/Color-yellow.JPG',
+            position: [0, 0.6, -3.3] as unknown as Vector3,
+            scale: 4 as unknown as Vector3,
+            rotation: [-0.165, 0, 0] as any
+          }}
+          style={{ backgroundColor: '#ffdd00' }}
+          keyLightIntensity={0.7}
+        >
+          <StatsGl />
+        </Avatar>
+        <div style={{ position: 'relative' }}>
+          <img
+            src={base64}
+            style={{ width: '100%', height: '100%', objectFit: 'contain', objectPosition: 'center' }}
+            alt="test preview"
+          />
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/components/Background/Box/Box.component.tsx
+++ b/src/components/Background/Box/Box.component.tsx
@@ -11,7 +11,7 @@ export const Box: FC<Background> = ({ src = '', ...baseProps }) => {
 
   return (
     <mesh ref={ref} castShadow receiveShadow {...baseProps}>
-      <boxBufferGeometry />
+      <boxGeometry />
       <meshPhysicalMaterial map={texture} />
     </mesh>
   );


### PR DESCRIPTION
Changes:

- For current version of threejs `<boxBufferGeometry />`  is deprecated so I've updated it to `<boxGeometry />` to make capture work again 
- And also added playground for capturing (check the video below)


https://github.com/user-attachments/assets/a6c4e8a1-56f1-4459-8715-000d70ccf1f9

