### PR TITLE
fix(animation): ACT-1237 animation name fix

### DIFF
--- a/src/components/Models/MultipleAnimationModel/MultipleAnimationModel.component.tsx
+++ b/src/components/Models/MultipleAnimationModel/MultipleAnimationModel.component.tsx
@@ -66,6 +66,7 @@ export const MultipleAnimationModel: FC<MultipleAnimationModelProps> = ({
     if (!newClip || !mixer || !animationConfig) return;
     if (prevAction && prevAction.getClip().name === newClip.name) return;
 
+    newClip.name = activeAnimation;
     const newAction = mixer.clipAction(newClip);
     const loopCount = animationConfig.repeat ?? Infinity;
     const fadeTime = animationConfig.fadeTime ?? 0.5;

--- a/src/components/Models/MultipleAnimationModel/MultipleAnimationModel.component.tsx
+++ b/src/components/Models/MultipleAnimationModel/MultipleAnimationModel.component.tsx
@@ -66,7 +66,6 @@ export const MultipleAnimationModel: FC<MultipleAnimationModelProps> = ({
     if (!newClip || !mixer || !animationConfig) return;
     if (prevAction && prevAction.getClip().name === newClip.name) return;
 
-    newClip.name = activeAnimation;
     const newAction = mixer.clipAction(newClip);
     const loopCount = animationConfig.repeat ?? Infinity;
     const fadeTime = animationConfig.fadeTime ?? 0.5;

--- a/src/services/Animation.service.ts
+++ b/src/services/Animation.service.ts
@@ -80,6 +80,7 @@ export const useAnimations = (animations: AnimationsT) =>
     await Promise.all(
       Object.keys(animations).map(async (name) => {
         const newClip = await loadAnimationClip(animations[name].source);
+        newClip.name = name;
         clips[name] = newClip;
       })
     );


### PR DESCRIPTION
The comparison was made on the clip names rather than what was given in the config, therefore all nova animations were called: 'Armature|Take 001|BaseLayer' and the comparison on line 67 was failing.

Fix is to give the name of the clip the name given to it in the config.