### PR TITLE
Rotation centered model added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readyplayerme/visage",
-  "version": "6.9.0",
+  "version": "6.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@readyplayerme/visage",
-      "version": "6.9.0",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
         "detect-gpu": "^5.0.41",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readyplayerme/visage",
-  "version": "6.9.0",
+  "version": "6.10.0",
   "description": "Easily display Ready Player Me avatars and 3D on the web.",
   "author": "Ready Player Me",
   "keywords": [

--- a/src/App/components/Develop.tsx
+++ b/src/App/components/Develop.tsx
@@ -10,7 +10,6 @@ import { SettingsPanel } from './SettingsPanel';
 export const AvatarDevelop: React.FC = () => (
   <>
     <SettingsPanel />
-
     <Avatar
       modelSrc="https://models.readyplayer.me/64d61e9e17883fd73ebe5eb7.glb?morphTargets=ARKit,Eyes Extra&textureAtlas=none&lod=0"
       shadows

--- a/src/App/components/Exhibit.tsx
+++ b/src/App/components/Exhibit.tsx
@@ -15,7 +15,7 @@ export const ExhibitPage = () => (
       lockVertical={false}
       lockHorizontal
       horizontalRotation
-      modelSrc="https://readyplayerme-assets.s3.amazonaws.com/animations/visage/headwear.glb"
+      modelSrc="https://files.readyplayer.dev/asset/modelUrl/04013f17-d197-49b8-9e7e-d782976b0b6f/a26d8ce7-5dcc-4d20-847a-6c8a69c5ed1f-1731509028078.glb"
     />
   </div>
 );

--- a/src/components/Models/CenteredModel/index.ts
+++ b/src/components/Models/CenteredModel/index.ts
@@ -1,0 +1,1 @@
+export { CenteredModel } from './CenteredModel.component';

--- a/src/components/Models/RotatingModel/RotatingModel.component.tsx
+++ b/src/components/Models/RotatingModel/RotatingModel.component.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, FC } from 'react';
 import { useFrame } from '@react-three/fiber';
 import type { Group } from 'three';
-import { Model } from 'src/components/Models/Model';
+import { CenteredModel } from 'src/components/Models/CenteredModel';
 import { useGltfLoader } from 'src/services';
 import { BaseModelProps } from 'src/types';
 
@@ -36,7 +36,7 @@ export const RotatingModel: FC<RotatingModelProps> = ({
   });
 
   return (
-    <Model
+    <CenteredModel
       verticalRotationStep={verticalRotationStep}
       horizontalRotationStep={horizontalRotationStep}
       lockHorizontal={lockHorizontal}


### PR DESCRIPTION
So the problem was the pivot point of the PZ assets - avatar bottom point. So now any idle-rotated asset for `Exhibit` get bound calcs to make the center of the asset the pivor point

![telegram-cloud-photo-size-2-5449847181596029612-y](https://github.com/user-attachments/assets/1d2e3f43-5bc4-4418-aa8d-9daafc32a901)
