### PR TITLE
Fix exhibit assets without clips

### DIFF
--- a/src/App/components/Exhibit.tsx
+++ b/src/App/components/Exhibit.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { Vector3 } from 'three';
 import { Exhibit } from 'src/components/Exhibit';
 
+const assets = {
+  posed:
+    'https://files.readyplayer.dev/asset/previewModelUrl/4976bb7b-e468-4652-be7e-479b0a3768d3/f326a138-d664-493c-8a8e-06abe9dd0423-1746692254239.glb',
+  default:
+    'https://files.readyplayer.dev/asset/modelUrl/12a084d2-fabe-4fb2-a2f3-903fdca078f7/a5a1c247-cbf5-4ec4-8b29-ec1646c2b567-1731444612287.glb'
+};
+
 export const ExhibitPage = () => (
   <div style={{ width: '100%', height: '100%', background: '#444' }}>
     <Exhibit
@@ -15,8 +22,7 @@ export const ExhibitPage = () => (
       lockVertical
       lockHorizontal={false}
       horizontalRotation
-      modelSrc="https://files.readyplayer.dev/asset/modelUrl/12a084d2-fabe-4fb2-a2f3-903fdca078f7/a5a1c247-cbf5-4ec4-8b29-ec1646c2b567-1731444612287.glb"
-      // modelSrc="https://files.readyplayer.dev/asset/previewModelUrl/4976bb7b-e468-4652-be7e-479b0a3768d3/f326a138-d664-493c-8a8e-06abe9dd0423-1746692254239.glb"
+      modelSrc={assets.posed}
     />
   </div>
 );

--- a/src/App/components/Exhibit.tsx
+++ b/src/App/components/Exhibit.tsx
@@ -15,7 +15,8 @@ export const ExhibitPage = () => (
       lockVertical
       lockHorizontal={false}
       horizontalRotation
-      modelSrc="https://files.readyplayer.dev/asset/previewModelUrl/bb715b27-635e-4c09-8ea9-f16a2bc085bf/668009a1-b417-4a1e-90e0-2055775b0abd-1746632664732.glb"
+      modelSrc="https://files.readyplayer.dev/asset/modelUrl/12a084d2-fabe-4fb2-a2f3-903fdca078f7/a5a1c247-cbf5-4ec4-8b29-ec1646c2b567-1731444612287.glb"
+      // modelSrc="https://files.readyplayer.dev/asset/previewModelUrl/4976bb7b-e468-4652-be7e-479b0a3768d3/f326a138-d664-493c-8a8e-06abe9dd0423-1746692254239.glb"
     />
   </div>
 );

--- a/src/components/Exhibit/Exhibit.component.tsx
+++ b/src/components/Exhibit/Exhibit.component.tsx
@@ -99,7 +99,7 @@ export const Exhibit: FC<ExhibitProps> = ({
     }
 
     if (float) {
-      return <FloatingModel modelSrc={modelSrc} scale={scale} />;
+      return <FloatingModel modelSrc={modelSrc} scale={scale} onLoaded={onLoaded} />;
     }
 
     if (horizontalRotation) {
@@ -109,14 +109,16 @@ export const Exhibit: FC<ExhibitProps> = ({
           horizontalRotationStep={horizontalRotationStep}
           modelSrc={modelSrc}
           scale={scale}
+          onLoaded={onLoaded}
           lockHorizontal={lockHorizontal}
           lockVertical={lockVertical}
         />
       );
     }
 
-    return <StaticModel modelSrc={modelSrc} scale={scale} />;
+    return <StaticModel modelSrc={modelSrc} scale={scale} onLoaded={onLoaded} />;
   }, [
+    onLoaded,
     float,
     modelSrc,
     scale,

--- a/src/components/Models/CenteredModel/CenteredModel.component.tsx
+++ b/src/components/Models/CenteredModel/CenteredModel.component.tsx
@@ -4,7 +4,7 @@ import { useThree } from '@react-three/fiber';
 import { normaliseMaterialsConfig, triggerCallback, usePersistantRotation } from 'src/services';
 import { hasWindow } from 'src/services/Client.service';
 import { BaseModelProps } from 'src/types';
-import { Spawn } from '../../Spawn/Spawn';
+import { Spawn } from 'src/components/Spawn/Spawn';
 
 interface ModelProps extends BaseModelProps {
   scene: Group;

--- a/src/components/Models/RotatingModel/RotatingModel.component.tsx
+++ b/src/components/Models/RotatingModel/RotatingModel.component.tsx
@@ -62,11 +62,16 @@ export const RotatingModel: FC<RotatingModelProps> = ({
       return mixer;
     }
 
-    const animation = mixer.clipAction(await animationClip);
-    animation.fadeIn(0);
-    animation.play();
+    const mixerAnimationClip = await animationClip;
 
-    mixer.update(0);
+    if (mixerAnimationClip) {
+      const animation = mixer.clipAction(mixerAnimationClip);
+
+      animation.fadeIn(0);
+      animation.play();
+
+      mixer.update(0);
+    }
 
     return mixer;
   }, [animationRunning, animationClip, nodes.Armature]);


### PR DESCRIPTION
Fixed:
- If `clip === []` skip animation play
- Added `onLoaded` missing props

Clips Issue
<img width="2052" alt="image" src="https://github.com/user-attachments/assets/44d3fed7-2a24-432f-aa67-a5154b9392ba" />
