### PR TITLE
feat: add mouse events to avatar

### DIFF
--- a/src/components/Avatar/Avatar.component.tsx
+++ b/src/components/Avatar/Avatar.component.tsx
@@ -24,7 +24,7 @@ import {
   MaterialConfiguration,
   SpawnState
 } from 'src/types';
-import { AnimationAction, Vector3, Mesh, MeshStandardMaterial } from 'three';
+import { AnimationAction, Vector3, Mesh } from 'three';
 
 import Lights from 'src/components/Lights/Lights.component';
 import { spawnState } from 'src/state/spawnAtom';
@@ -192,9 +192,9 @@ export interface AvatarProps extends LightingProps, EnvironmentProps, Omit<BaseM
    */
   onMeshHoverEnd?: (mesh: Mesh) => void;
   /**
-   * Callback for processing materials.
+   * Callback for processing meshes on model load.
    */
-  materialCallback?: (material: MeshStandardMaterial) => void;
+  meshCallback?: (mesh: Mesh) => void;
 }
 
 /**
@@ -249,7 +249,7 @@ const Avatar: FC<AvatarProps> = ({
   onMeshClick,
   onMeshHoverStart,
   onMeshHoverEnd,
-  materialCallback
+  meshCallback
 }) => {
   const setSpawnState = useSetAtom(spawnState);
 
@@ -277,7 +277,7 @@ const Avatar: FC<AvatarProps> = ({
           onMeshClick={onMeshClick}
           onMeshHoverStart={onMeshHoverStart}
           onMeshHoverEnd={onMeshHoverEnd}
-          materialCallback={materialCallback}
+          meshCallback={meshCallback}
         />
       );
     }
@@ -297,7 +297,7 @@ const Avatar: FC<AvatarProps> = ({
           onMeshClick={onMeshClick}
           onMeshHoverStart={onMeshHoverStart}
           onMeshHoverEnd={onMeshHoverEnd}
-          materialCallback={materialCallback}
+          meshCallback={meshCallback}
         />
       );
     }
@@ -316,7 +316,7 @@ const Avatar: FC<AvatarProps> = ({
           onMeshClick={onMeshClick}
           onMeshHoverStart={onMeshHoverStart}
           onMeshHoverEnd={onMeshHoverEnd}
-          materialCallback={materialCallback}
+          meshCallback={meshCallback}
         />
       );
     }
@@ -334,7 +334,7 @@ const Avatar: FC<AvatarProps> = ({
           onMeshClick={onMeshClick}
           onMeshHoverStart={onMeshHoverStart}
           onMeshHoverEnd={onMeshHoverEnd}
-          materialCallback={materialCallback}
+          meshCallback={meshCallback}
         />
       );
     }
@@ -350,7 +350,7 @@ const Avatar: FC<AvatarProps> = ({
         onMeshClick={onMeshClick}
         onMeshHoverStart={onMeshHoverStart}
         onMeshHoverEnd={onMeshHoverEnd}
-        materialCallback={materialCallback}
+        meshCallback={meshCallback}
       />
     );
   }, [
@@ -371,7 +371,7 @@ const Avatar: FC<AvatarProps> = ({
     onMeshClick,
     onMeshHoverStart,
     onMeshHoverEnd,
-    materialCallback
+    meshCallback
   ]);
 
   useEffect(() => triggerCallback(onLoading), [modelSrc, animationSrc, onLoading]);

--- a/src/components/Avatar/Avatar.component.tsx
+++ b/src/components/Avatar/Avatar.component.tsx
@@ -24,7 +24,7 @@ import {
   MaterialConfiguration,
   SpawnState
 } from 'src/types';
-import { AnimationAction, Vector3 } from 'three';
+import { AnimationAction, Vector3, Mesh, MeshStandardMaterial } from 'three';
 
 import Lights from 'src/components/Lights/Lights.component';
 import { spawnState } from 'src/state/spawnAtom';
@@ -179,6 +179,22 @@ export interface AvatarProps extends LightingProps, EnvironmentProps, Omit<BaseM
    */
   canvasConfig?: CanvasConfiguration;
   animatedCameraSrc?: string;
+  /**
+   * Callback for when a mesh is clicked.
+   */
+  onMeshClick?: (mesh: Mesh) => void;
+  /**
+   * Callback for when a mesh hover starts.
+   */
+  onMeshHoverStart?: (mesh: Mesh) => void;
+  /**
+   * Callback for when a mesh hover ends.
+   */
+  onMeshHoverEnd?: (mesh: Mesh) => void;
+  /**
+   * Callback for processing materials.
+   */
+  materialCallback?: (material: MeshStandardMaterial) => void;
 }
 
 /**
@@ -229,7 +245,11 @@ const Avatar: FC<AvatarProps> = ({
   materialConfig,
   controlsMinDistance,
   controlsMaxDistance,
-  canvasConfig
+  canvasConfig,
+  onMeshClick,
+  onMeshHoverStart,
+  onMeshHoverEnd,
+  materialCallback
 }) => {
   const setSpawnState = useSetAtom(spawnState);
 
@@ -254,6 +274,10 @@ const Avatar: FC<AvatarProps> = ({
           bloom={effects?.bloom}
           onAnimationEnd={onAnimationEnd}
           materialConfig={materialConfig}
+          onMeshClick={onMeshClick}
+          onMeshHoverStart={onMeshHoverStart}
+          onMeshHoverEnd={onMeshHoverEnd}
+          materialCallback={materialCallback}
         />
       );
     }
@@ -270,6 +294,10 @@ const Avatar: FC<AvatarProps> = ({
           headMovement={headMovement}
           bloom={effects?.bloom}
           materialConfig={materialConfig}
+          onMeshClick={onMeshClick}
+          onMeshHoverStart={onMeshHoverStart}
+          onMeshHoverEnd={onMeshHoverEnd}
+          materialCallback={materialCallback}
         />
       );
     }
@@ -285,6 +313,10 @@ const Avatar: FC<AvatarProps> = ({
           headMovement={headMovement}
           bloom={effects?.bloom}
           materialConfig={materialConfig}
+          onMeshClick={onMeshClick}
+          onMeshHoverStart={onMeshHoverStart}
+          onMeshHoverEnd={onMeshHoverEnd}
+          materialCallback={materialCallback}
         />
       );
     }
@@ -299,6 +331,10 @@ const Avatar: FC<AvatarProps> = ({
           onLoaded={onLoaded}
           bloom={effects?.bloom}
           materialConfig={materialConfig}
+          onMeshClick={onMeshClick}
+          onMeshHoverStart={onMeshHoverStart}
+          onMeshHoverEnd={onMeshHoverEnd}
+          materialCallback={materialCallback}
         />
       );
     }
@@ -311,6 +347,10 @@ const Avatar: FC<AvatarProps> = ({
         emotion={emotion}
         bloom={effects?.bloom}
         materialConfig={materialConfig}
+        onMeshClick={onMeshClick}
+        onMeshHoverStart={onMeshHoverStart}
+        onMeshHoverEnd={onMeshHoverEnd}
+        materialCallback={materialCallback}
       />
     );
   }, [
@@ -327,7 +367,11 @@ const Avatar: FC<AvatarProps> = ({
     materialConfig,
     onAnimationEnd,
     idleRotation,
-    headMovement
+    headMovement,
+    onMeshClick,
+    onMeshHoverStart,
+    onMeshHoverEnd,
+    materialCallback
   ]);
 
   useEffect(() => triggerCallback(onLoading), [modelSrc, animationSrc, onLoading]);

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -241,6 +241,10 @@ export default {
     cameraInitialDistance: { control: { type: 'range', min: 0, max: 2.5, step: 0.01 } },
     onLoaded: { control: false },
     environment: { options: Object.keys(environmentPresets), control: { type: 'select' } },
-    fov: { control: { type: 'range', min: 30, max: 100, step: 1 } }
+    fov: { control: { type: 'range', min: 30, max: 100, step: 1 } },
+    onMeshClick: { control: false },
+    onMeshHoverStart: { control: false },
+    onMeshHoverEnd: { control: false },
+    materialCallback: { control: false }
   }
 };

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -245,6 +245,6 @@ export default {
     onMeshClick: { control: false },
     onMeshHoverStart: { control: false },
     onMeshHoverEnd: { control: false },
-    materialCallback: { control: false }
+    meshCallback: { control: false }
   }
 };

--- a/src/components/Avatar/Examples.stories.tsx
+++ b/src/components/Avatar/Examples.stories.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { StoryFn } from '@storybook/react';
 import { Sparkles as SparklesDrei } from '@react-three/drei';
 import type { Meta } from '@storybook/react';
 import { Avatar as AvatarWrapper, CAMERA } from 'src/components/Avatar';
 import { getStoryAssetPath } from 'src/services';
 import { ignoreArgTypesOnExamples, emotions, modelPresets, animationPresets } from 'src/services/Stories.service';
-import { Vector3 } from 'three';
+import { Mesh, MeshStandardMaterial, Vector3 } from 'three';
 import { AvatarProps } from './Avatar.component';
 import { Static } from './Avatar.stories';
 import { BloomConfiguration } from '../../types';
@@ -154,3 +154,84 @@ IdleBlinking.argTypes = {
   modelSrc: { options: Object.values({ seven: modelPresets.seven }), control: { type: 'select' } },
   animationSrc: { options: Object.values(animationPresets), control: { type: 'select' } }
 };
+
+const highlightMaterial = new MeshStandardMaterial({ color: '#ff0000', transparent: false });
+
+export const MouseActions: StoryFn<typeof Avatar> = (args) => {
+  const [originalMaterials] = useState(new Map());
+
+  const handleModelClick = (mesh: Mesh) => {
+    console.log('Clicked mesh:', mesh);
+  };
+
+  const dimClothMaterials = (material: MeshStandardMaterial) => {
+    const materialWhitelist = ['Wolf3D_Outfit_Top', 'Wolf3D_Outfit_Bottom', 'Wolf3D_Hair', 'Wolf3D_Outfit_Footwear'];
+
+    if (!materialWhitelist.includes(material.name)) {
+      return;
+    }
+
+    material.color.setHex(0x404040);
+    // eslint-disable-next-line no-param-reassign
+    material.roughness = 0.8;
+    // eslint-disable-next-line no-param-reassign
+    material.metalness = 0.1;
+  };
+
+  const onMeshHoverStart = useCallback(
+    (mesh: Mesh) => {
+      const meshWhiteList = ['Wolf3D_Outfit_Top', 'Wolf3D_Outfit_Bottom', 'Wolf3D_Hair', 'Wolf3D_Outfit_Footwear'];
+
+      if (!meshWhiteList.includes(mesh?.name)) {
+        return;
+      }
+
+      document.body.style.cursor = 'pointer';
+
+      // Store original material and set hover highlight for the new mesh
+      if (!originalMaterials.has(mesh.name)) {
+        originalMaterials.set(mesh.name, mesh.material);
+
+        // eslint-disable-next-line no-param-reassign
+        mesh.material = highlightMaterial;
+      }
+    },
+    [originalMaterials]
+  );
+
+  const onMeshHoverEnd = useCallback(
+    (mesh: Mesh) => {
+      const originalMaterial = originalMaterials.get(mesh.name);
+
+      if (originalMaterial) {
+        document.body.style.cursor = 'default';
+        // eslint-disable-next-line no-param-reassign
+        mesh.material = originalMaterial;
+        originalMaterials.delete(mesh.name);
+      }
+    },
+    [originalMaterials]
+  );
+
+  return (
+    <Avatar
+      {...args}
+      onMeshClick={handleModelClick}
+      materialCallback={dimClothMaterials}
+      onMeshHoverStart={onMeshHoverStart}
+      onMeshHoverEnd={onMeshHoverEnd}
+    />
+  );
+};
+
+MouseActions.args = {
+  ...Static.args,
+  modelSrc: getStoryAssetPath('male.glb'),
+  cameraTarget: CAMERA.TARGET.FULL_BODY.MALE,
+  cameraInitialDistance: CAMERA.CONTROLS.FULL_BODY.MAX_DISTANCE,
+  background: {
+    color: 'rgba(134, 157, 169, 1)'
+  }
+};
+
+MouseActions.argTypes = {};

--- a/src/components/Avatar/Examples.stories.tsx
+++ b/src/components/Avatar/Examples.stories.tsx
@@ -164,18 +164,19 @@ export const MouseActions: StoryFn<typeof Avatar> = (args) => {
     console.log('Clicked mesh:', mesh);
   };
 
-  const dimClothMaterials = (material: MeshStandardMaterial) => {
-    const materialWhitelist = ['Wolf3D_Outfit_Top', 'Wolf3D_Outfit_Bottom', 'Wolf3D_Hair', 'Wolf3D_Outfit_Footwear'];
+  const dimClothMaterials = (mesh: Mesh) => {
+    const meshWhitelist = ['Wolf3D_Outfit_Top', 'Wolf3D_Outfit_Bottom', 'Wolf3D_Hair', 'Wolf3D_Outfit_Footwear'];
 
-    if (!materialWhitelist.includes(material.name)) {
+    if (!meshWhitelist.includes(mesh.name)) {
       return;
     }
 
+    const material = mesh.material as MeshStandardMaterial;
     material.color.setHex(0x404040);
-    // eslint-disable-next-line no-param-reassign
     material.roughness = 0.8;
-    // eslint-disable-next-line no-param-reassign
     material.metalness = 0.1;
+    material.emissive.setHex(0xffffff);
+    material.emissiveIntensity = 0.1;
   };
 
   const onMeshHoverStart = useCallback(
@@ -217,7 +218,7 @@ export const MouseActions: StoryFn<typeof Avatar> = (args) => {
     <Avatar
       {...args}
       onMeshClick={handleModelClick}
-      materialCallback={dimClothMaterials}
+      meshCallback={dimClothMaterials}
       onMeshHoverStart={onMeshHoverStart}
       onMeshHoverEnd={onMeshHoverEnd}
     />

--- a/src/components/Models/AnimationModel/AnimationModel.component.tsx
+++ b/src/components/Models/AnimationModel/AnimationModel.component.tsx
@@ -40,7 +40,7 @@ export const AnimationModel: FC<AnimationModelProps> = ({
   onMeshClick,
   onMeshHoverStart,
   onMeshHoverEnd,
-  materialCallback
+  meshCallback
 }) => {
   const ref = useRef<Group>(null);
   const [animationRunning, setAnimationRunning] = useState(true);
@@ -115,7 +115,7 @@ export const AnimationModel: FC<AnimationModelProps> = ({
       onMeshClick={onMeshClick}
       onMeshHoverStart={onMeshHoverStart}
       onMeshHoverEnd={onMeshHoverEnd}
-      materialCallback={materialCallback}
+      meshCallback={meshCallback}
     />
   );
 };

--- a/src/components/Models/AnimationModel/AnimationModel.component.tsx
+++ b/src/components/Models/AnimationModel/AnimationModel.component.tsx
@@ -36,7 +36,11 @@ export const AnimationModel: FC<AnimationModelProps> = ({
   headMovement = false,
   emotion,
   bloom,
-  materialConfig
+  materialConfig,
+  onMeshClick,
+  onMeshHoverStart,
+  onMeshHoverEnd,
+  materialCallback
 }) => {
   const ref = useRef<Group>(null);
   const [animationRunning, setAnimationRunning] = useState(true);
@@ -57,7 +61,7 @@ export const AnimationModel: FC<AnimationModelProps> = ({
 
       assetMixerRef.current = null;
     };
-  }, [scene]);
+  }, [scene, embeddedAnimations]);
 
   const animationClip = useMemo(async () => {
     const clip = await loadAnimationClips(animationSrc);
@@ -108,6 +112,10 @@ export const AnimationModel: FC<AnimationModelProps> = ({
       onSpawnAnimationFinish={onSpawnAnimationFinish}
       bloom={bloom}
       materialConfig={materialConfig}
+      onMeshClick={onMeshClick}
+      onMeshHoverStart={onMeshHoverStart}
+      onMeshHoverEnd={onMeshHoverEnd}
+      materialCallback={materialCallback}
     />
   );
 };

--- a/src/components/Models/FloatingModel/FloatingModel.component.tsx
+++ b/src/components/Models/FloatingModel/FloatingModel.component.tsx
@@ -10,7 +10,16 @@ export interface FloatingModelProps extends BaseModelProps {
   scale?: number;
 }
 
-export const FloatingModel: FC<FloatingModelProps> = ({ modelSrc, scale = 1.0, onLoaded, bloom }) => {
+export const FloatingModel: FC<FloatingModelProps> = ({
+  modelSrc,
+  scale = 1.0,
+  onLoaded,
+  bloom,
+  onMeshClick,
+  onMeshHoverStart,
+  onMeshHoverEnd,
+  materialCallback
+}) => {
   const ref = useRef<Group>(null);
   const { scene } = useGltfLoader(modelSrc);
 
@@ -23,5 +32,17 @@ export const FloatingModel: FC<FloatingModelProps> = ({ modelSrc, scale = 1.0, o
     }
   });
 
-  return <Model modelRef={ref} scale={scale} scene={scene} onLoaded={onLoaded} bloom={bloom} />;
+  return (
+    <Model
+      modelRef={ref}
+      scale={scale}
+      scene={scene}
+      onLoaded={onLoaded}
+      bloom={bloom}
+      onMeshClick={onMeshClick}
+      onMeshHoverStart={onMeshHoverStart}
+      onMeshHoverEnd={onMeshHoverEnd}
+      materialCallback={materialCallback}
+    />
+  );
 };

--- a/src/components/Models/FloatingModel/FloatingModel.component.tsx
+++ b/src/components/Models/FloatingModel/FloatingModel.component.tsx
@@ -18,7 +18,7 @@ export const FloatingModel: FC<FloatingModelProps> = ({
   onMeshClick,
   onMeshHoverStart,
   onMeshHoverEnd,
-  materialCallback
+  meshCallback
 }) => {
   const ref = useRef<Group>(null);
   const { scene } = useGltfLoader(modelSrc);
@@ -42,7 +42,7 @@ export const FloatingModel: FC<FloatingModelProps> = ({
       onMeshClick={onMeshClick}
       onMeshHoverStart={onMeshHoverStart}
       onMeshHoverEnd={onMeshHoverEnd}
-      materialCallback={materialCallback}
+      meshCallback={meshCallback}
     />
   );
 };

--- a/src/components/Models/HalfBodyModel/HalfBodyModel.component.tsx
+++ b/src/components/Models/HalfBodyModel/HalfBodyModel.component.tsx
@@ -27,7 +27,11 @@ export const HalfBodyModel: FC<HalfBodyModelProps> = ({
   onLoaded,
   headMovement = false,
   bloom,
-  materialConfig
+  materialConfig,
+  onMeshClick,
+  onMeshHoverStart,
+  onMeshHoverEnd,
+  materialCallback
 }) => {
   const ref = useRef<Group>(null);
   const { scene } = useGltfLoader(modelSrc);
@@ -72,6 +76,10 @@ export const HalfBodyModel: FC<HalfBodyModelProps> = ({
       onLoaded={onLoaded}
       bloom={bloom}
       materialConfig={materialConfig}
+      onMeshClick={onMeshClick}
+      onMeshHoverStart={onMeshHoverStart}
+      onMeshHoverEnd={onMeshHoverEnd}
+      materialCallback={materialCallback}
     />
   );
 };

--- a/src/components/Models/HalfBodyModel/HalfBodyModel.component.tsx
+++ b/src/components/Models/HalfBodyModel/HalfBodyModel.component.tsx
@@ -31,7 +31,7 @@ export const HalfBodyModel: FC<HalfBodyModelProps> = ({
   onMeshClick,
   onMeshHoverStart,
   onMeshHoverEnd,
-  materialCallback
+  meshCallback
 }) => {
   const ref = useRef<Group>(null);
   const { scene } = useGltfLoader(modelSrc);
@@ -79,7 +79,7 @@ export const HalfBodyModel: FC<HalfBodyModelProps> = ({
       onMeshClick={onMeshClick}
       onMeshHoverStart={onMeshHoverStart}
       onMeshHoverEnd={onMeshHoverEnd}
-      materialCallback={materialCallback}
+      meshCallback={meshCallback}
     />
   );
 };

--- a/src/components/Models/Model/Model.component.tsx
+++ b/src/components/Models/Model/Model.component.tsx
@@ -1,7 +1,7 @@
 import React, { FC, Ref, useEffect, useState, useCallback, useMemo } from 'react';
 import { Group, Mesh } from 'three';
 import { normaliseMaterialsConfig, triggerCallback, usePersistantRotation } from 'src/services';
-import { useThree } from '@react-three/fiber';
+import { ThreeEvent, useThree } from '@react-three/fiber';
 import { hasWindow } from 'src/services/Client.service';
 import { BaseModelProps } from 'src/types';
 import { Spawn } from '../../Spawn/Spawn';
@@ -22,7 +22,11 @@ export const Model: FC<ModelProps> = ({
   onLoaded,
   onSpawnAnimationFinish,
   bloom,
-  materialConfig
+  materialConfig,
+  onMeshClick,
+  onMeshHoverStart,
+  onMeshHoverEnd,
+  materialCallback
 }) => {
   const { gl } = useThree();
   const [isTouching, setIsTouching] = useState(false);
@@ -60,7 +64,7 @@ export const Model: FC<ModelProps> = ({
     [isTouching, touchEvent, scene]
   );
 
-  normaliseMaterialsConfig(scene, bloom, materialConfig);
+  normaliseMaterialsConfig(scene, bloom, materialConfig, materialCallback);
 
   scene.traverse((object) => {
     const node = object;
@@ -70,6 +74,51 @@ export const Model: FC<ModelProps> = ({
       node.receiveShadow = true;
     }
   });
+
+  const onClick = useCallback(
+    (event: ThreeEvent<MouseEvent>) => {
+      if (!onMeshClick) {
+        return;
+      }
+
+      const mesh = event.object as Mesh;
+
+      if (mesh && mesh.isMesh) {
+        onMeshClick(mesh);
+      }
+    },
+    [onMeshClick]
+  );
+
+  const handlePointerEnter = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      if (!onMeshHoverStart) {
+        return;
+      }
+      const mesh = event.object as Mesh;
+
+      if (mesh && mesh.isMesh) {
+        event.stopPropagation();
+        onMeshHoverStart(mesh);
+      }
+    },
+    [onMeshHoverStart]
+  );
+
+  const handlePointerLeave = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      if (!onMeshHoverEnd) {
+        return;
+      }
+      const mesh = event.object as Mesh;
+
+      if (mesh && mesh.isMesh) {
+        event.stopPropagation();
+        onMeshHoverEnd(mesh);
+      }
+    },
+    [onMeshHoverEnd]
+  );
 
   useEffect(() => triggerCallback(onLoaded), [scene, onLoaded]);
 
@@ -101,7 +150,14 @@ export const Model: FC<ModelProps> = ({
   );
 
   return (
-    <group ref={modelRef} dispose={null} rotation={[0, 0, 0]}>
+    <group
+      ref={modelRef}
+      dispose={null}
+      rotation={[0, 0, 0]}
+      onClick={onClick}
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
+    >
       <primitive object={scene} scale={scale} />
       {spawnComponent}
     </group>

--- a/src/components/Models/Model/Model.component.tsx
+++ b/src/components/Models/Model/Model.component.tsx
@@ -1,6 +1,6 @@
 import React, { FC, Ref, useEffect, useState, useCallback, useMemo } from 'react';
 import { Group, Mesh } from 'three';
-import { normaliseMaterialsConfig, triggerCallback, usePersistantRotation } from 'src/services';
+import { normaliseMaterialsConfig, traverseMeshes, triggerCallback, usePersistantRotation } from 'src/services';
 import { ThreeEvent, useThree } from '@react-three/fiber';
 import { hasWindow } from 'src/services/Client.service';
 import { BaseModelProps } from 'src/types';
@@ -26,7 +26,7 @@ export const Model: FC<ModelProps> = ({
   onMeshClick,
   onMeshHoverStart,
   onMeshHoverEnd,
-  materialCallback
+  meshCallback
 }) => {
   const { gl } = useThree();
   const [isTouching, setIsTouching] = useState(false);
@@ -64,7 +64,7 @@ export const Model: FC<ModelProps> = ({
     [isTouching, touchEvent, scene]
   );
 
-  normaliseMaterialsConfig(scene, bloom, materialConfig, materialCallback);
+  normaliseMaterialsConfig(scene, bloom, materialConfig);
 
   scene.traverse((object) => {
     const node = object;
@@ -74,6 +74,10 @@ export const Model: FC<ModelProps> = ({
       node.receiveShadow = true;
     }
   });
+
+  if (meshCallback) {
+    traverseMeshes(scene, meshCallback);
+  }
 
   const onClick = useCallback(
     (event: ThreeEvent<MouseEvent>) => {

--- a/src/components/Models/MultipleAnimationModel/MultipleAnimationModel.component.tsx
+++ b/src/components/Models/MultipleAnimationModel/MultipleAnimationModel.component.tsx
@@ -32,7 +32,11 @@ export const MultipleAnimationModel: FC<MultipleAnimationModelProps> = ({
   emotion,
   bloom,
   materialConfig,
-  onAnimationEnd
+  onAnimationEnd,
+  onMeshClick,
+  onMeshHoverStart,
+  onMeshHoverEnd,
+  materialCallback
 }) => {
   const armatureMixerRef = useRef<AnimationMixer | null>(null);
   const assetMixerRef = useRef<Array<AnimationMixer> | null>(null);
@@ -66,7 +70,7 @@ export const MultipleAnimationModel: FC<MultipleAnimationModelProps> = ({
       disposeAssetAnimations(assetMixerRef.current, scene);
       assetMixerRef.current = null;
     };
-  }, [scene]);
+  }, [scene, embeddedAnimations]);
 
   useEffect(() => {
     const mixer = armatureMixerRef.current;
@@ -119,5 +123,17 @@ export const MultipleAnimationModel: FC<MultipleAnimationModelProps> = ({
   useIdleExpression('blink', scene);
   useFallbackScene(scene, setModelFallback);
 
-  return <Model scene={scene} scale={scale} onLoaded={onLoaded} bloom={bloom} materialConfig={materialConfig} />;
+  return (
+    <Model
+      scene={scene}
+      scale={scale}
+      onLoaded={onLoaded}
+      bloom={bloom}
+      materialConfig={materialConfig}
+      onMeshClick={onMeshClick}
+      onMeshHoverStart={onMeshHoverStart}
+      onMeshHoverEnd={onMeshHoverEnd}
+      materialCallback={materialCallback}
+    />
+  );
 };

--- a/src/components/Models/MultipleAnimationModel/MultipleAnimationModel.component.tsx
+++ b/src/components/Models/MultipleAnimationModel/MultipleAnimationModel.component.tsx
@@ -36,7 +36,7 @@ export const MultipleAnimationModel: FC<MultipleAnimationModelProps> = ({
   onMeshClick,
   onMeshHoverStart,
   onMeshHoverEnd,
-  materialCallback
+  meshCallback
 }) => {
   const armatureMixerRef = useRef<AnimationMixer | null>(null);
   const assetMixerRef = useRef<Array<AnimationMixer> | null>(null);
@@ -133,7 +133,7 @@ export const MultipleAnimationModel: FC<MultipleAnimationModelProps> = ({
       onMeshClick={onMeshClick}
       onMeshHoverStart={onMeshHoverStart}
       onMeshHoverEnd={onMeshHoverEnd}
-      materialCallback={materialCallback}
+      meshCallback={meshCallback}
     />
   );
 };

--- a/src/components/Models/PoseModel/PoseModel.component.tsx
+++ b/src/components/Models/PoseModel/PoseModel.component.tsx
@@ -23,7 +23,11 @@ export const PoseModel: FC<PoseModelProps> = ({
   setModelFallback,
   onLoaded,
   bloom,
-  materialConfig
+  materialConfig,
+  onMeshClick,
+  onMeshHoverStart,
+  onMeshHoverEnd,
+  materialCallback
 }) => {
   const { scene } = useGltfLoader(modelSrc);
   const { nodes } = useGraph(scene);
@@ -42,6 +46,10 @@ export const PoseModel: FC<PoseModelProps> = ({
       onLoaded={onLoaded}
       bloom={bloom}
       materialConfig={materialConfig}
+      onMeshClick={onMeshClick}
+      onMeshHoverStart={onMeshHoverStart}
+      onMeshHoverEnd={onMeshHoverEnd}
+      materialCallback={materialCallback}
     />
   );
 };

--- a/src/components/Models/PoseModel/PoseModel.component.tsx
+++ b/src/components/Models/PoseModel/PoseModel.component.tsx
@@ -27,7 +27,7 @@ export const PoseModel: FC<PoseModelProps> = ({
   onMeshClick,
   onMeshHoverStart,
   onMeshHoverEnd,
-  materialCallback
+  meshCallback
 }) => {
   const { scene } = useGltfLoader(modelSrc);
   const { nodes } = useGraph(scene);
@@ -49,7 +49,7 @@ export const PoseModel: FC<PoseModelProps> = ({
       onMeshClick={onMeshClick}
       onMeshHoverStart={onMeshHoverStart}
       onMeshHoverEnd={onMeshHoverEnd}
-      materialCallback={materialCallback}
+      meshCallback={meshCallback}
     />
   );
 };

--- a/src/components/Models/StaticModel/StaticModel.component.tsx
+++ b/src/components/Models/StaticModel/StaticModel.component.tsx
@@ -21,7 +21,11 @@ export const StaticModel: FC<StaticModelProps> = ({
   onLoaded,
   emotion,
   bloom,
-  materialConfig
+  materialConfig,
+  onMeshClick,
+  onMeshHoverStart,
+  onMeshHoverEnd,
+  materialCallback
 }) => {
   const { scene } = useGltfLoader(modelSrc);
   const { nodes } = useGraph(scene);
@@ -37,6 +41,10 @@ export const StaticModel: FC<StaticModelProps> = ({
       onLoaded={onLoaded}
       bloom={bloom}
       materialConfig={materialConfig}
+      onMeshClick={onMeshClick}
+      onMeshHoverStart={onMeshHoverStart}
+      onMeshHoverEnd={onMeshHoverEnd}
+      materialCallback={materialCallback}
     />
   );
 };

--- a/src/components/Models/StaticModel/StaticModel.component.tsx
+++ b/src/components/Models/StaticModel/StaticModel.component.tsx
@@ -25,7 +25,7 @@ export const StaticModel: FC<StaticModelProps> = ({
   onMeshClick,
   onMeshHoverStart,
   onMeshHoverEnd,
-  materialCallback
+  meshCallback
 }) => {
   const { scene } = useGltfLoader(modelSrc);
   const { nodes } = useGraph(scene);
@@ -44,7 +44,7 @@ export const StaticModel: FC<StaticModelProps> = ({
       onMeshClick={onMeshClick}
       onMeshHoverStart={onMeshHoverStart}
       onMeshHoverEnd={onMeshHoverEnd}
-      materialCallback={materialCallback}
+      meshCallback={meshCallback}
     />
   );
 };

--- a/src/services/Models.service.tsx
+++ b/src/services/Models.service.tsx
@@ -85,6 +85,14 @@ function traverseMaterials(object: Object3D, callback: (material: Material) => v
   });
 }
 
+export function traverseMeshes(object: Object3D, callback: (material: Mesh) => void) {
+  object.traverse((node) => {
+    const mesh = node as Mesh;
+    if (!mesh.geometry || !mesh.isMesh) return;
+    callback(mesh);
+  });
+}
+
 const disposeGltfScene = (scene: Group<Object3DEventMap>) => {
   scene.traverse((node) => {
     if (node instanceof SkinnedMesh && node.skeleton) {
@@ -116,8 +124,7 @@ const disposeGltfScene = (scene: Group<Object3DEventMap>) => {
 export const normaliseMaterialsConfig = (
   scene: Group<Object3DEventMap>,
   bloomConfig?: BloomConfiguration,
-  materialConfig?: MaterialConfiguration,
-  customCallback?: (material: MeshStandardMaterial) => void
+  materialConfig?: MaterialConfiguration
 ) => {
   traverseMaterials(scene, (material: Material) => {
     const mat = material as MeshStandardMaterial;
@@ -132,10 +139,6 @@ export const normaliseMaterialsConfig = (
 
     if (mat.emissiveMap) {
       mat.emissiveIntensity = bloomConfig?.materialIntensity ?? materialConfig?.emissiveIntensity ?? 3.3;
-    }
-
-    if (customCallback) {
-      customCallback(mat);
     }
   });
 };

--- a/src/services/Models.service.tsx
+++ b/src/services/Models.service.tsx
@@ -116,7 +116,8 @@ const disposeGltfScene = (scene: Group<Object3DEventMap>) => {
 export const normaliseMaterialsConfig = (
   scene: Group<Object3DEventMap>,
   bloomConfig?: BloomConfiguration,
-  materialConfig?: MaterialConfiguration
+  materialConfig?: MaterialConfiguration,
+  customCallback?: (material: MeshStandardMaterial) => void
 ) => {
   traverseMaterials(scene, (material: Material) => {
     const mat = material as MeshStandardMaterial;
@@ -131,6 +132,10 @@ export const normaliseMaterialsConfig = (
 
     if (mat.emissiveMap) {
       mat.emissiveIntensity = bloomConfig?.materialIntensity ?? materialConfig?.emissiveIntensity ?? 3.3;
+    }
+
+    if (customCallback) {
+      customCallback(mat);
     }
   });
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import { Vector3 } from 'three';
+import { Vector3, Mesh, MeshStandardMaterial } from 'three';
 import { PresetsType } from '@react-three/drei/helpers/environment-assets';
 
 export type Required<T> = {
@@ -53,6 +53,22 @@ export interface BaseModelProps {
   setModelFallback?: (fallback: JSX.Element) => void;
   bloom?: BloomConfiguration;
   materialConfig?: MaterialConfiguration;
+  /**
+   * Callback for when a mesh is clicked.
+   */
+  onMeshClick?: (mesh: Mesh) => void;
+  /**
+   * Callback for when a mesh hover starts.
+   */
+  onMeshHoverStart?: (mesh: Mesh) => void;
+  /**
+   * Callback for when a mesh hover ends.
+   */
+  onMeshHoverEnd?: (mesh: Mesh) => void;
+  /**
+   * Callback for processing materials.
+   */
+  materialCallback?: (material: MeshStandardMaterial) => void;
 }
 
 export type HeadBlendShapeType =

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import { Vector3, Mesh, MeshStandardMaterial } from 'three';
+import { Vector3, Mesh } from 'three';
 import { PresetsType } from '@react-three/drei/helpers/environment-assets';
 
 export type Required<T> = {
@@ -66,9 +66,9 @@ export interface BaseModelProps {
    */
   onMeshHoverEnd?: (mesh: Mesh) => void;
   /**
-   * Callback for processing materials.
+   * Callback for processing meshes on model load.
    */
-  materialCallback?: (material: MeshStandardMaterial) => void;
+  meshCallback?: (material: Mesh) => void;
 }
 
 export type HeadBlendShapeType =


### PR DESCRIPTION
## Changes

- added optional click/hover handlers to avatar meshes
- added ability to modify avatar mesh materials during runtime

## Testing
- avatar -> examples -> mouseevents in storybook
- clothes/hair should highlight on hover
- onclick you should see which mesh was clicked in console
